### PR TITLE
Add non-root user to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,11 @@ RUN apk update && apk add --no-cache ffmpeg \
 
 COPY . .
 
+RUN adduser -D -H -u 1000 trailer-finder \
+      && chown -R trailer-finder:trailer-finder /app
+
 RUN rm -rf /usr/local/bin/pip /usr/local/bin/pip3
+
+USER trailer-finder
 
 CMD ["python", "-u", "main.py"]


### PR DESCRIPTION

- Using a non-root user for added security
- Clearly defining the application's entry point
- Ensuring better log visibility with unbuffered mode